### PR TITLE
🎨 UI: Adjust slider bar layout and unify testing frameworks

### DIFF
--- a/SwiftViewer/Views/SettingsView.swift
+++ b/SwiftViewer/Views/SettingsView.swift
@@ -102,13 +102,10 @@ struct SettingsView: View {
             
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    Text("Interval:")
-                        .frame(width: 100, alignment: .leading)
-                    
                     Slider(value: $slideShowIntervalIndex, in: 0.0...Double(SlideshowIntervalHelper.intervals.count - 1), step: 1.0) {
                         Text("Slideshow Interval")
                     }
-                    .frame(maxWidth: 300)
+                    .frame(maxWidth: 500)
                     .onChange(of: slideShowIntervalIndex) { _, newIndex in
                         let snappedIndex = Int(round(newIndex))
                         let actualInterval = SlideshowIntervalHelper.intervalForIndex(snappedIndex)
@@ -127,18 +124,6 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.leading, 100)
-                
-                // Quick presets
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Quick Presets:")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                    
-                    SlideShowPresetsView(
-                        selectedInterval: $slideShowInterval,
-                        intervals: settingsManager.slideShowPresetIntervals
-                    )
-                }
                 
                 Toggle("Repeat slideshow", isOn: Binding(
                     get: { settingsManager.repeatEnabled },
@@ -166,13 +151,10 @@ struct SettingsView: View {
                         .fontWeight(.medium)
                     
                     HStack {
-                        Text("Radius:")
-                            .frame(width: 60, alignment: .leading)
-                        
                         Slider(value: $blurRadius, in: 0.0...50.0, step: 1.0) {
                             Text("Blur Radius")
                         }
-                        .frame(maxWidth: 200)
+                        .frame(maxWidth: 500)
                         .onChange(of: blurRadius) { _, newValue in
                             settingsManager.blurRadius = newValue
                             NotificationCenter.default.post(name: .blurSettingsChanged, object: nil)
@@ -184,13 +166,10 @@ struct SettingsView: View {
                     }
                     
                     HStack {
-                        Text("Opacity:")
-                            .frame(width: 60, alignment: .leading)
-                        
                         Slider(value: $blurOpacity, in: 0.0...1.0, step: 0.1) {
                             Text("Blur Opacity")
                         }
-                        .frame(maxWidth: 200)
+                        .frame(maxWidth: 500)
                         .onChange(of: blurOpacity) { _, newValue in
                             settingsManager.blurOpacity = newValue
                             NotificationCenter.default.post(name: .blurSettingsChanged, object: nil)
@@ -210,9 +189,6 @@ struct SettingsView: View {
                     
                     ForEach(AnimationType.allCases, id: \.self) { type in
                         HStack {
-                            Text("\(type.displayName):")
-                                .frame(width: 90, alignment: .leading)
-                            
                             Slider(
                                 value: bindingForAnimationType(type),
                                 in: 0.1...1.0,
@@ -220,7 +196,7 @@ struct SettingsView: View {
                             ) {
                                 Text("\(type.displayName) Duration")
                             }
-                            .frame(maxWidth: 150)
+                            .frame(maxWidth: 500)
                             
                             Text(String(format: "%.1fs", animationDurations[type] ?? type.defaultDuration))
                                 .font(.system(.caption, design: .monospaced))
@@ -242,13 +218,10 @@ struct SettingsView: View {
             
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    Text("Auto-hide delay:")
-                        .frame(width: 120, alignment: .leading)
-                    
-                    Slider(value: $autoHideDelay, in: 1.0...60.0, step: 0.5) {
+                    Slider(value: $autoHideDelay, in: 1.0...60.0, step: 1.0) {
                         Text("Auto-hide Delay")
                     }
-                    .frame(maxWidth: 200)
+                    .frame(maxWidth: 500)
                     .onChange(of: autoHideDelay) { _, newValue in
                         settingsManager.autoHideDelay = newValue
                         NotificationCenter.default.post(name: .autoHideDelayChanged, object: nil)

--- a/SwiftViewerTests/SwiftViewerTests.swift
+++ b/SwiftViewerTests/SwiftViewerTests.swift
@@ -5,12 +5,12 @@
 //  Created by sho kisaragi on 2025/08/21.
 //
 
-import Testing
+import XCTest
 
-struct SwiftViewerTests {
+final class SwiftViewerTests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testExample() async throws {
+        // Write your test here and use APIs like `XCTAssert*(...)` to check expected conditions.
     }
 
 }

--- a/SwiftViewerTests/Utilities/LoggerTests.swift
+++ b/SwiftViewerTests/Utilities/LoggerTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import Testing
 @testable import SwiftViewer
 
 final class LoggerTests: XCTestCase {
@@ -41,10 +40,8 @@ final class LoggerTests: XCTestCase {
         let logger = Logger.shared
         let testMessage = "Test debug message"
         
-        withKnownIssue("Debug logging produces expected console output in test environment") {
-            // Verify debug logging doesn't crash and works when enabled
-            XCTAssertNoThrow(logger.debug(testMessage))
-        }
+        // Verify debug logging doesn't crash and works when enabled
+        XCTAssertNoThrow(logger.debug(testMessage))
     }
     
     func test_logger_doesNotLogDebugMessage_whenDebugLoggingDisabled() {
@@ -74,20 +71,16 @@ final class LoggerTests: XCTestCase {
         let logger = Logger.shared
         let testMessage = "Test info message"
         
-        withKnownIssue("Info logging produces expected console output in test environment") {
-            // Verify info logging doesn't crash
-            XCTAssertNoThrow(logger.info(testMessage))
-        }
+        // Verify info logging doesn't crash
+        XCTAssertNoThrow(logger.info(testMessage))
     }
     
     func test_logger_logsWarningMessage() {
         let logger = Logger.shared
         let testMessage = "Test warning message"
         
-        withKnownIssue("Warning logging produces expected console output in test environment") {
-            // Verify warning logging doesn't crash
-            XCTAssertNoThrow(logger.warning(testMessage))
-        }
+        // Verify warning logging doesn't crash
+        XCTAssertNoThrow(logger.warning(testMessage))
     }
     
     func test_logger_logsErrorMessage() {
@@ -95,10 +88,8 @@ final class LoggerTests: XCTestCase {
         let testMessage = "Test error message"
         let testError = NSError(domain: "TestDomain", code: 1, userInfo: nil)
         
-        withKnownIssue("Error logging produces expected console output in test environment") {
-            // Verify error logging doesn't crash with error object
-            XCTAssertNoThrow(logger.error(testMessage, error: testError))
-        }
+        // Verify error logging doesn't crash with error object
+        XCTAssertNoThrow(logger.error(testMessage, error: testError))
     }
     
     func test_logger_error_without_error_object() {
@@ -106,10 +97,8 @@ final class LoggerTests: XCTestCase {
         let logger = Logger.shared
         let message = "Something went wrong"
         
-        withKnownIssue("Error logging without error object produces expected console output") {
-            // When - This should not crash
-            XCTAssertNoThrow(logger.error(message))
-        }
+        // When - This should not crash
+        XCTAssertNoThrow(logger.error(message))
     }
     
     // MARK: - Message Formatting Tests

--- a/SwiftViewerTests/Utils/LogCapture.swift
+++ b/SwiftViewerTests/Utils/LogCapture.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Testing
+import XCTest
 @testable import SwiftViewer
 
 /// Utility for capturing and validating log output in tests

--- a/SwiftViewerTests/ViewModels/ImageGalleryViewModelTests.swift
+++ b/SwiftViewerTests/ViewModels/ImageGalleryViewModelTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import Testing
 import AppKit
 @testable import SwiftViewer
 
@@ -90,15 +89,11 @@ final class ImageGalleryViewModelTests: XCTestCase {
         mockFileManagerService.shouldThrowError = true
         mockFileManagerService.errorToThrow = FileManagerServiceError.directoryNotFound
         
-        await withKnownIssue("FileManager error handling produces expected error logging output") {
-            await sut.loadFolder(testURL)
-            
-            XCTAssertNotNil(sut.errorMessage)
-            XCTAssertTrue(sut.imageFiles.isEmpty)
-            XCTAssertNil(sut.currentImage)
-            
-            // Log capture validation can be extended here if needed
-        }
+        await sut.loadFolder(testURL)
+        
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertTrue(sut.imageFiles.isEmpty)
+        XCTAssertNil(sut.currentImage)
     }
     
     func test_loadFolder_handlesEmptyFolder() async {
@@ -202,14 +197,10 @@ final class ImageGalleryViewModelTests: XCTestCase {
         await setupWithImages(count: 3)
         mockImageLoaderService.shouldThrowError = true
         
-        await withKnownIssue("ImageLoader error handling produces expected error logging output") {
-            await sut.navigateToIndex(1)
-            
-            XCTAssertNotNil(sut.errorMessage)
-            XCTAssertNil(sut.currentImage)
-            
-            // Log capture validation can be extended here if needed
-        }
+        await sut.navigateToIndex(1)
+        
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertNil(sut.currentImage)
     }
     
     // MARK: - Sort Tests

--- a/SwiftViewerTests/Views/ViewLoggingIntegrationTests.swift
+++ b/SwiftViewerTests/Views/ViewLoggingIntegrationTests.swift
@@ -7,7 +7,6 @@
 
 @testable import SwiftViewer
 import XCTest
-import Testing
 
 final class ViewLoggingIntegrationTests: XCTestCase {
     
@@ -34,12 +33,8 @@ final class ViewLoggingIntegrationTests: XCTestCase {
             NSLocalizedDescriptionKey: "Folder not found"
         ])
         
-        withKnownIssue("ContentView error logging produces expected console output") {
-            // Then - Should not crash when logging error with Error parameter
-            XCTAssertNoThrow(logger.error("Error selecting folder", error: testError))
-            
-            // Record structured log data for validation
-        }
+        // Then - Should not crash when logging error with Error parameter
+        XCTAssertNoThrow(logger.error("Error selecting folder", error: testError))
     }
     
     func test_contentView_should_log_display_mode_changes() {
@@ -49,12 +44,8 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // When - This tests that Logger.shared.info can be called for display mode changes
         let displayMode = "fit" // Simulating DisplayMode.rawValue
         
-        withKnownIssue("ContentView display mode logging produces expected console output") {
-            // Then - Should not crash when logging display mode changes
-            XCTAssertNoThrow(logger.info("Display mode changed to: \(displayMode)"))
-            
-            // Record structured log data for validation
-        }
+        // Then - Should not crash when logging display mode changes
+        XCTAssertNoThrow(logger.info("Display mode changed to: \(displayMode)"))
     }
     
     // MARK: - FolderSelectionView Logging Tests
@@ -66,15 +57,11 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // When - This tests that Logger.shared.debug can be called for folder selection
         let testPath = "/Users/test/Pictures"
         
-        withKnownIssue("FolderSelectionView debug logging produces expected console output when enabled") {
-            // Enable debug logging for this test
-            UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
-            
-            // Then - Should not crash when logging folder selection
-            XCTAssertNoThrow(logger.debug("Folder selected: \(testPath)"))
-            
-            // Record structured log data for validation
-        }
+        // Enable debug logging for this test
+        UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
+        
+        // Then - Should not crash when logging folder selection
+        XCTAssertNoThrow(logger.debug("Folder selected: \(testPath)"))
     }
     
     // MARK: - SlideShowControlsView Preview Logging Tests
@@ -83,19 +70,15 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // Given
         let logger = Logger.shared
         
-        withKnownIssue("SlideShowControlsView preview logging produces expected console output when enabled") {
-            // Enable debug logging for this test
-            UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
-            
-            // When - This tests that Logger.shared.debug can be called for preview actions
-            // Then - Should not crash when logging various preview actions
-            XCTAssertNoThrow(logger.debug("Preview: Previous button tapped"))
-            XCTAssertNoThrow(logger.debug("Preview: Toggle slideshow"))
-            XCTAssertNoThrow(logger.debug("Preview: Next button tapped"))
-            XCTAssertNoThrow(logger.debug("Preview: Toggle repeat"))
-            
-            // Record structured log data for validation
-        }
+        // Enable debug logging for this test
+        UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
+        
+        // When - This tests that Logger.shared.debug can be called for preview actions
+        // Then - Should not crash when logging various preview actions
+        XCTAssertNoThrow(logger.debug("Preview: Previous button tapped"))
+        XCTAssertNoThrow(logger.debug("Preview: Toggle slideshow"))
+        XCTAssertNoThrow(logger.debug("Preview: Next button tapped"))
+        XCTAssertNoThrow(logger.debug("Preview: Toggle repeat"))
     }
     
     // MARK: - Logger Method Signature Validation
@@ -109,13 +92,9 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         let message = "Test error message"
         let error: Error = NSError(domain: "TestDomain", code: 123, userInfo: nil)
         
-        withKnownIssue("Logger error method signature validation produces expected console output") {
-            // When & Then - Should compile and not crash
-            XCTAssertNoThrow(logger.error(message, error: error))
-            XCTAssertNoThrow(logger.error(message)) // Also test without error parameter
-            
-            // Record structured log data for validation
-        }
+        // When & Then - Should compile and not crash
+        XCTAssertNoThrow(logger.error(message, error: error))
+        XCTAssertNoThrow(logger.error(message)) // Also test without error parameter
     }
     
     func test_logger_supports_basic_logging_methods() {
@@ -124,15 +103,11 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // Given
         let logger = Logger.shared
         
-        withKnownIssue("Basic logging methods produce expected console output") {
-            // When & Then - Test current methods work
-            XCTAssertNoThrow(logger.info("Test info message"))
-            XCTAssertNoThrow(logger.debug("Test debug message"))
-            XCTAssertNoThrow(logger.error("Test error message"))
-            XCTAssertNoThrow(logger.warning("Test warning message"))
-            
-            // Record structured log data for validation
-        }
+        // When & Then - Test current methods work
+        XCTAssertNoThrow(logger.info("Test info message"))
+        XCTAssertNoThrow(logger.debug("Test debug message"))
+        XCTAssertNoThrow(logger.error("Test error message"))
+        XCTAssertNoThrow(logger.warning("Test warning message"))
     }
     
     // MARK: - Debug Mode Integration Tests
@@ -147,15 +122,11 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // When & Then - Debug calls should not crash (even if not logged)
         XCTAssertNoThrow(logger.debug("Debug message from view"))
         
-        withKnownIssue("Debug logging integration produces expected console output when enabled") {
-            // Given - Debug logging enabled
-            UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
-            
-            // When & Then - Debug calls should not crash
-            XCTAssertNoThrow(logger.debug("Debug message from view with logging enabled"))
-            
-            // Record structured log data for validation
-        }
+        // Given - Debug logging enabled
+        UserDefaults.standard.set(true, forKey: "debugLoggingEnabled")
+        
+        // When & Then - Debug calls should not crash
+        XCTAssertNoThrow(logger.debug("Debug message from view with logging enabled"))
     }
     
     // MARK: - Error Integration Edge Cases
@@ -168,12 +139,8 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         let message = "Error occurred"
         let nilError: Error? = nil
         
-        withKnownIssue("Logger handles nil error gracefully and produces expected console output") {
-            // When & Then - Should handle nil error gracefully
-            XCTAssertNoThrow(logger.error(message, error: nilError))
-            
-            // Record structured log data for validation
-        }
+        // When & Then - Should handle nil error gracefully
+        XCTAssertNoThrow(logger.error(message, error: nilError))
     }
     
     func test_logger_handles_empty_messages_gracefully() {
@@ -182,13 +149,9 @@ final class ViewLoggingIntegrationTests: XCTestCase {
         // Given
         let logger = Logger.shared
         
-        withKnownIssue("Logger handles edge case messages and produces expected console output") {
-            // When & Then - Should handle edge cases gracefully
-            XCTAssertNoThrow(logger.info("")) // Empty message
-            XCTAssertNoThrow(logger.debug("   ")) // Whitespace message  
-            XCTAssertNoThrow(logger.error("Special chars: 日本語 🎉 @#$%")) // Unicode and special chars
-            
-            // Record structured log data for validation
-        }
+        // When & Then - Should handle edge cases gracefully
+        XCTAssertNoThrow(logger.info("")) // Empty message
+        XCTAssertNoThrow(logger.debug("   ")) // Whitespace message  
+        XCTAssertNoThrow(logger.error("Special chars: 日本語 🎉 @#$%")) // Unicode and special chars
     }
 }


### PR DESCRIPTION
## Summary

- Clean up SettingsView slider layout by removing unnecessary labels and constraints
- Resolve testing framework mixing issue that was blocking commits

## Changes Made

### UI Improvements

- **Slider Layout Cleanup**: Remove text labels from sliders (Interval, Radius, Opacity, Auto-hide delay)
- **Unified Width**: Expand all slider widths to consistent `maxWidth: 500`
- **Simplified UI**: Remove "Quick Presets" section for cleaner interface
- **Step Adjustment**: Change auto-hide delay step from 0.5 to 1.0 for better UX

### Testing Framework Unification

- **Framework Consistency**: Convert 5 test files from Swift Testing to XCTest
- **Import Changes**: `import Testing` → `import XCTest`
- **Test Structure**: `@Test` annotations → `func test_*() throws` methods
- **Class Structure**: `struct` → `final class: XCTestCase`
- **Assertion Updates**: Remove `withKnownIssue` blocks, use direct assertions

## Technical Details

### Files Modified

**UI Changes:**

- `SwiftViewer/Views/SettingsView.swift` - Slider layout adjustments

**Testing Framework:**

- `SwiftViewerTests/SwiftViewerTests.swift` - Basic structure conversion
- `SwiftViewerTests/Utils/LogCapture.swift` - Import update
- `SwiftViewerTests/Utilities/LoggerTests.swift` - Logger test conversion
- `SwiftViewerTests/Views/ViewLoggingIntegrationTests.swift` - Integration test conversion
- `SwiftViewerTests/ViewModels/ImageGalleryViewModelTests.swift` - ViewModel test conversion

### Problem Solved

- **Mixed Testing Frameworks**: Was blocking commits due to pre-commit hook detecting both Swift Testing and XCTest
- **Framework Consistency**: Now all tests use XCTest uniformly
- **Pre-commit Validation**: All checks now pass (Build ✅, Tests ✅, Framework Consistency ✅)

## Test Plan

- [x] Build succeeds without errors
- [x] All 26 unit tests pass
- [x] Pre-commit hook passes framework consistency check
- [x] UI sliders display correctly with new layout
- [x] Settings functionality remains intact

## Screenshots

Settings UI now has cleaner, more consistent slider layout without redundant labels.

🤖 Generated with [Claude Code](https://claude.ai/code)