### PR TITLE
refactor: dedup test assertion helpers and hoist animation durations constant

### DIFF
--- a/SwiftViewer/Services/SettingsManager.swift
+++ b/SwiftViewer/Services/SettingsManager.swift
@@ -139,13 +139,13 @@ final class SettingsManager: SettingsManagerProtocol {
     var animationDurations: [AnimationType: TimeInterval] {
         get {
             guard let data = userDefaults.data(forKey: "animationDurations") else {
-                return defaultAnimationDurations
+                return Self.defaultAnimationDurations
             }
             do {
                 return try JSONDecoder().decode([AnimationType: TimeInterval].self, from: data)
             } catch {
                 Logger.shared.warning("Failed to decode animationDurations: \(error.localizedDescription)")
-                return defaultAnimationDurations
+                return Self.defaultAnimationDurations
             }
         }
         set {
@@ -158,9 +158,8 @@ final class SettingsManager: SettingsManagerProtocol {
         }
     }
 
-    private var defaultAnimationDurations: [AnimationType: TimeInterval] {
+    private static let defaultAnimationDurations: [AnimationType: TimeInterval] =
         [.control: 0.3, .transition: 0.2, .feedback: 0.1]
-    }
     
     var blurRadius: Double {
         get {

--- a/SwiftViewerTests/Services/ImageLoaderServiceTests.swift
+++ b/SwiftViewerTests/Services/ImageLoaderServiceTests.swift
@@ -47,6 +47,20 @@ final class ImageLoaderServiceTests: XCTestCase {
         try pngData.write(to: url)
     }
 
+    private func assertLoadImageThrows(
+        _ expectedError: ImageLoaderError,
+        from url: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await sut.loadImage(from: url)
+            XCTFail("Expected \(expectedError) error", file: file, line: line)
+        } catch {
+            XCTAssertEqual(error as? ImageLoaderError, expectedError, file: file, line: line)
+        }
+    }
+
     // MARK: - Tests
 
     func test_loadImage_validPNG_returnsNSImage() async throws {
@@ -63,35 +77,20 @@ final class ImageLoaderServiceTests: XCTestCase {
     func test_loadImage_fileNotFound_throwsFileNotFoundError() async {
         let nonExistentURL = tempDirectory.appendingPathComponent("nonexistent.jpg")
 
-        do {
-            _ = try await sut.loadImage(from: nonExistentURL)
-            XCTFail("Expected fileNotFound error")
-        } catch {
-            XCTAssertEqual(error as? ImageLoaderError, .fileNotFound)
-        }
+        await assertLoadImageThrows(.fileNotFound, from: nonExistentURL)
     }
 
     func test_loadImage_invalidData_throwsInvalidImageError() async throws {
         let invalidURL = tempDirectory.appendingPathComponent("invalid.jpg")
         try Data("not an image".utf8).write(to: invalidURL)
 
-        do {
-            _ = try await sut.loadImage(from: invalidURL)
-            XCTFail("Expected invalidImage error")
-        } catch {
-            XCTAssertEqual(error as? ImageLoaderError, .invalidImage)
-        }
+        await assertLoadImageThrows(.invalidImage, from: invalidURL)
     }
 
     func test_loadImage_emptyFile_throwsInvalidImageError() async throws {
         let emptyURL = tempDirectory.appendingPathComponent("empty.png")
         try Data().write(to: emptyURL)
 
-        do {
-            _ = try await sut.loadImage(from: emptyURL)
-            XCTFail("Expected invalidImage error")
-        } catch {
-            XCTAssertEqual(error as? ImageLoaderError, .invalidImage)
-        }
+        await assertLoadImageThrows(.invalidImage, from: emptyURL)
     }
 }

--- a/SwiftViewerTests/ViewModels/ContentViewModelTests.swift
+++ b/SwiftViewerTests/ViewModels/ContentViewModelTests.swift
@@ -26,6 +26,14 @@ final class ContentViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Helpers
+
+    private func assertPostsNotification(_ name: Notification.Name, when action: () -> Void) {
+        let expectation = expectation(forNotification: name, object: nil)
+        action()
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - Initialization
 
     func test_init_loadsSortTypeFromSettings() {
@@ -64,11 +72,9 @@ final class ContentViewModelTests: XCTestCase {
     }
 
     func test_updateSortType_postsNotification() {
-        let expectation = expectation(forNotification: .sortTypeChanged, object: nil)
-
-        sut.updateSortType(.random)
-
-        wait(for: [expectation], timeout: 1.0)
+        assertPostsNotification(.sortTypeChanged) {
+            sut.updateSortType(.random)
+        }
     }
 
     // MARK: - Display Mode Management
@@ -80,11 +86,9 @@ final class ContentViewModelTests: XCTestCase {
     }
 
     func test_updateDisplayMode_postsNotification() {
-        let expectation = expectation(forNotification: .displayModeChanged, object: nil)
-
-        sut.updateDisplayMode(.fill)
-
-        wait(for: [expectation], timeout: 1.0)
+        assertPostsNotification(.displayModeChanged) {
+            sut.updateDisplayMode(.fill)
+        }
     }
 
     // MARK: - Fullscreen Management
@@ -100,11 +104,9 @@ final class ContentViewModelTests: XCTestCase {
     }
 
     func test_toggleFullscreen_postsNotification() {
-        let expectation = expectation(forNotification: .fullscreenToggled, object: nil)
-
-        sut.toggleFullscreen()
-
-        wait(for: [expectation], timeout: 1.0)
+        assertPostsNotification(.fullscreenToggled) {
+            sut.toggleFullscreen()
+        }
     }
 
     // MARK: - Repeat Management
@@ -126,11 +128,9 @@ final class ContentViewModelTests: XCTestCase {
     }
 
     func test_toggleRepeat_postsNotification() {
-        let expectation = expectation(forNotification: .repeatModeChanged, object: nil)
-
-        sut.toggleRepeat()
-
-        wait(for: [expectation], timeout: 1.0)
+        assertPostsNotification(.repeatModeChanged) {
+            sut.toggleRepeat()
+        }
     }
 
     // MARK: - Window Position Management
@@ -148,10 +148,8 @@ final class ContentViewModelTests: XCTestCase {
     }
 
     func test_updateWindowPosition_postsNotification() {
-        let expectation = expectation(forNotification: .windowPositionChanged, object: nil)
-
-        sut.updateWindowPosition(.alwaysOnTop)
-
-        wait(for: [expectation], timeout: 1.0)
+        assertPostsNotification(.windowPositionChanged) {
+            sut.updateWindowPosition(.alwaysOnTop)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `SettingsManager`: convert `defaultAnimationDurations` from a computed property (re-allocated on every read) to a `private static let` constant; update the two call sites to `Self.defaultAnimationDurations`
- `ContentViewModelTests`: extract an `assertPostsNotification(_:when:)` helper, replacing the notification-expectation block copy-pasted across 5 tests
- `ImageLoaderServiceTests`: extract an async `assertLoadImageThrows(_:from:)` helper (with `#filePath`/`#line` forwarding) replacing the `do/catch` error-assertion duplicated across 3 tests

No behavior change — quality cleanups surfaced by `/simplify`.

## Test plan

- [x] `xcodebuild ... build` succeeds (verified by pre-commit hook)
- [x] `xcodebuild ... test` passes — 466 tests, 0 failures
- [x] Framework consistency check passes