### PR TITLE
docs: align README with the current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,55 @@
 
 [![Swift CI](https://github.com/sho7650/SwiftViewer/actions/workflows/swift.yml/badge.svg)](https://github.com/sho7650/SwiftViewer/actions/workflows/swift.yml)
 [![Swift](https://img.shields.io/badge/Swift-6.0-orange.svg)](https://swift.org)
-[![Platform](https://img.shields.io/badge/Platform-macOS%2014.0%2B-blue.svg)](https://developer.apple.com/macos/)
+[![Platform](https://img.shields.io/badge/Platform-macOS%2026.0%2B-blue.svg)](https://developer.apple.com/macos/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-A modern, high-performance photo viewer application for macOS built with Swift 6 and SwiftUI. SwiftViewer provides a clean, intuitive interface for browsing and viewing large collections of images with advanced slideshow functionality.
+A modern, high-performance photo viewer for macOS built with Swift 6 and SwiftUI. SwiftViewer provides a clean, intuitive interface for browsing large image collections, with a slideshow, configurable transitions, and a Liquid Glass control bar that stays out of your way.
 
 ## ✨ Features
 
 ### 🖼️ Image Viewing
-- **Multi-format Support**: JPG, JPEG, HEIC, GIF (with animation support)
-- **High Performance**: Optimized for folders containing 10,000+ images
-- **Smart Caching**: Sub-10ms response time for cached images with configurable memory limits
-- **Folder-based Navigation**: Easy browsing of entire image directories
+- **Formats**: JPEG (`.jpg`, `.jpeg`), HEIC (`.heic`), and animated GIF (`.gif`)
+- **Built for large folders**: designed to handle 10,000+ images in a single directory
+- **Actor-isolated image pipeline**: ImageIO downsampling behind an `NSCache`, with neighbouring images preloaded in the background
+- **Configurable cache**: memory ceiling as a share of system RAM, image count limit, and preload window
+- **Blurred backdrop**: non-image areas are filled with a blurred copy of the current photo (radius and opacity adjustable)
 
 ### 🎬 Slideshow
-- **Configurable Intervals**: 1-300 seconds with precise timing
-- **Smooth Transitions**: Fluid image transitions with auto-hide controls
-- **Repeat Mode**: Continuous playback or stop at last image
-- **Keyboard Control**: Space bar to play/pause, arrow keys for navigation
+- **13 preset intervals**: 1s, 2s, 3s, 5s, 10s, 20s, 30s, 1m, 2m, 5m, 10m, 20m, 30m
+- **Six transitions**: Cross Dissolve, Zoom In, Zoom Out, Blur Replace, Blur Replace (Expand), None
+- **Adjustable transition duration**: 0.1–5.0 seconds
+- **Repeat mode**: loop continuously or stop at the last image
+- **Keyboard control**: Space to play/pause, arrow keys to navigate
 
 ### 🎛️ User Interface
-- **Auto-hide Controls**: Smart control visibility based on user activity
-- **Progress Bar Navigation**: Click-to-jump functionality with visual progress
-- **Fullscreen Support**: Immersive viewing experience (F key toggle)
-- **Responsive Design**: Optimized for various screen sizes and orientations
+- **Liquid Glass controls**: native `.glass` / `.glassProminent` styling, with Play/Pause raised as the primary action
+- **Auto-hide controls**: the player fades out after a configurable delay (1–60 s, default 3 s) and returns on activity. Arrow-key navigation is deliberately exempt, so keyboard browsing stays distraction-free
+- **Progress bar**: click to jump, or drag to scrub — navigation commits once on release, so scrubbing a huge folder never floods the image pipeline
+- **Fullscreen**: ⌘F
+- **Window layering**: keep the window always on top or always on bottom
 
 ### 📁 Organization
-- **Multiple Sort Options**:
-  - Name (ascending/descending)
-  - Date created (ascending/descending)
-  - File size (ascending/descending)
+- **Sort options**:
+  - Name (A–Z / Z–A)
+  - Date created (oldest / newest first)
+  - File size (smallest / largest first)
   - Random shuffle
-- **Real-time Sorting**: Instant re-organization without reload
+- **Real-time sorting**: instant re-ordering without reloading the folder
 
 ### ⚙️ Settings & Customization
-- **Persistent Settings**: Preferences saved automatically
-- **Slideshow Timing**: Customizable interval settings
-- **Display Modes**: Fit to window, fill window, or actual size
-- **Keyboard Shortcuts**: Full keyboard navigation support
+- **Persistent preferences**: stored in `UserDefaults` and applied live
+- **Display modes**: Fit to Window, Fill Window, Actual Size
+- **Slideshow interval**, **transition type and duration**, **auto-hide delay**
+- **Backdrop blur**: radius and opacity
+- **Cache tuning**: memory limit (1–50 % of system RAM, default 15 %), count limit (default 100), preload window (default 10)
+- **Logging level**: Debug / Info / Warning / Error
 
 ## 🚀 Getting Started
 
 ### Requirements
-- macOS 15.0 or later
-- Xcode 16+ (for development)
+- macOS 26.0 (Tahoe) or later
+- Xcode 26+ (for development)
 
 ### Installation
 
@@ -66,88 +71,108 @@ Download the latest release from the [Releases](https://github.com/sho7650/Swift
 
 3. Build and run:
    - Select the SwiftViewer scheme
-   - Press ⌘+R to build and run
+   - Press ⌘R to build and run
 
 ## 📖 Usage
 
 ### Basic Navigation
-- **Open Folder**: Use File menu or drag & drop a folder onto the app
-- **Navigate Images**: 
-  - ← → arrow keys for previous/next
-  - Click on progress bar to jump to specific image
-  - Mouse wheel for quick scrolling
+- **Open a folder**: File ▸ Open Folder… (⌘O)
+- **Navigate images**:
+  - ← → (or ↑ ↓) for previous/next
+  - Click the progress bar to jump to a specific image
+  - Drag the progress bar to scrub through the folder
 
 ### Slideshow Controls
-- **Start/Stop**: Space bar or click the play/pause button
-- **Settings**: Configure timing via Preferences (⌘+,)
-- **Repeat Mode**: Toggle continuous playback via menu or ⌘+R
+- **Start/Stop**: Space, or the Play/Pause button in the control bar
+- **Settings**: Preferences (⌘,)
+- **Repeat mode**: View ▸ Toggle Repeat Slideshow (⌘R), or the repeat button in the control bar
 
 ### Keyboard Shortcuts
+
 | Key | Action |
 |-----|--------|
-| ← | Previous image |
-| → | Next image |
+| ← / ↑ | Previous image |
+| → / ↓ | Next image |
 | Space | Toggle slideshow |
-| F | Toggle fullscreen |
-| ⌘+R | Toggle repeat mode |
-| ⌘+, | Open preferences |
-| ⌘+O | Open folder |
+| ⌘O | Open folder |
+| ⌘, | Open preferences |
+| ⌘F | Toggle fullscreen |
+| ⌘R | Toggle repeat mode |
+| ⌘1 / ⌘2 / ⌘3 | Fit to Window / Fill Window / Actual Size |
+| ⌥⌘1 / ⇧⌥⌘1 | Sort by name, A–Z / Z–A |
+| ⌥⌘2 / ⇧⌥⌘2 | Sort by date, oldest / newest first |
+| ⌥⌘3 / ⇧⌥⌘3 | Sort by size, smallest / largest first |
+| ⌥⌘R | Random shuffle |
+| ⌃⌘T | Always on Top |
+| ⌃⌘B | Always on Bottom |
+
+> Arrow keys navigate without waking the auto-hidden control bar. Any other input — Space, other keys, mouse movement, or clicking the controls — brings it back.
 
 ### Display Modes
-- **Fit to Window**: Scale image to fit window while maintaining aspect ratio
-- **Fill Window**: Scale image to fill entire window
-- **Actual Size**: Display image at original resolution
+- **Fit to Window**: scale to fit while maintaining aspect ratio
+- **Fill Window**: scale to fill the entire window
+- **Actual Size**: display at original resolution
 
 ## 🏗️ Architecture
 
-SwiftViewer follows a clean MVVM architecture with dependency injection:
+SwiftViewer follows an MVVM architecture with protocol-based dependency injection.
 
 ### Core Components
-- **ViewModels**: Business logic and state management
-  - `ImageGalleryViewModel`: Main gallery functionality
-  - `SlideShowViewModel`: Slideshow control and timing
-  - `AutoHideControlsManager`: Smart UI control visibility
-  
-- **Services**: Backend functionality
-  - `FileManagerService`: File system operations
-  - `ImageLoaderService`: Optimized image loading
-  - `SettingsManager`: Persistent user preferences
-  - `SlideShowService`: Timer management
 
-- **Views**: SwiftUI interface components
-  - `ImageGalleryView`: Main image display
-  - `GlassmorphismControlsView`: Playback controls
-  - `SettingsView`: Preferences interface
+- **ViewModels**
+  - `ImageGalleryViewModel` — folder contents, current index, navigation
+  - `SlideShowViewModel` — slideshow state and timing
+  - `AutoHideControlsManager` — control-bar visibility and the hide timer
+  - `ContentViewModel` — folder selection and top-level app state
+
+- **Services**
+  - `FileManagerService` — directory scanning and image filtering
+  - `ImagePipeline` — `actor` wrapping ImageIO downsampling, an `NSCache`, and background preloading (`ImageDownsampler`, `ImagePipelineProtocol`)
+  - `SettingsManager` — `UserDefaults`-backed preferences
+  - `SlideShowService` — timer management
+  - `TransitionManager` / `ScaleFadeTransition` — pluggable image transitions
+  - `WindowController` — fullscreen and window layering
+  - `DependencyContainer` — composition root, with a mock container for tests and previews
+
+- **Views**
+  - `ImageGalleryView` — main image display and key handling
+  - `GlassmorphismControlsView` — Liquid Glass player bar and progress scrubber
+  - `BlurredImageBackground` — blurred backdrop
+  - `SimpleAnimatedImageView` — animated GIF playback
+  - `FolderSelectionView`, `SettingsView`
 
 ### Key Design Patterns
-- **Protocol-oriented Programming**: Maximum testability and flexibility
-- **Dependency Injection**: Clean separation of concerns
-- **Observer Pattern**: Reactive UI updates
-- **Command Pattern**: Menu and keyboard actions
+- **Protocol-oriented programming** for testability
+- **Dependency injection** through initializers
+- **`@Observable` state** for reactive UI updates
+- **Command pattern** for menu and keyboard actions (`MenuCommands`)
+- **Swift 6 strict concurrency**: actors for shared mutable state, `@MainActor` for UI
 
 ## 🧪 Testing
 
-SwiftViewer includes comprehensive test coverage:
-
 ```bash
 # Run all tests
-xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer test
+xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer -sdk macosx test
 
-# Run with coverage
+# Run only the unit test target
+xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer -sdk macosx -only-testing:SwiftViewerTests test
+
+# Run with the coverage test plan
 xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer -testPlan TestCoveragePlan test
 ```
 
+Current suite: **427 unit tests** and **4 UI tests**.
+
 ### Test Structure
-- **Unit Tests**: Logic and business rule validation
-- **UI Tests**: User interface and interaction testing
-- **Integration Tests**: Component interaction verification
-- **Performance Tests**: Load testing with large image collections
+- **Unit tests** (`SwiftViewerTests/`) — logic and business rules, mirroring the source tree
+- **UI tests** (`SwiftViewerUITests/`) — launch and interaction
+- **Performance tests** — rendering and load behaviour with large collections
 
 ## 🔧 Development
 
 ### Prerequisites
-- Xcode 16+
-- macOS 15.0+
+- macOS 26.0+
+- Xcode 26+
 - Swift 6.0
 
 ### Building
@@ -159,65 +184,79 @@ xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer -configuration Deb
 xcodebuild -project SwiftViewer.xcodeproj -scheme SwiftViewer -configuration Release build
 ```
 
+### Linting
+```bash
+swiftlint          # rules in .swiftlint.yml
+swiftlint --fix    # auto-fix
+```
+
 ### Code Style
-- Follow Swift API Design Guidelines
-- Use SwiftUI best practices
-- Maintain MVVM separation
-- Write comprehensive unit tests
+- Follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)
+- Prefer value types and `let`; use actors for shared mutable state
+- Maintain MVVM separation and inject dependencies through protocols
+- Write tests first — the project targets 75 %+ coverage
 
 ### Contributing
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+2. Create a feature branch (`git checkout -b feat/amazing-feature`)
 3. Make your changes with tests
-4. Ensure all tests pass
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+4. Ensure the build and full test suite pass — a pre-commit hook runs `scripts/verify_prerequisites.sh` (build + tests) and blocks the commit on failure
+5. Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`)
+6. Push and open a Pull Request
+
+See [docs/RELEASING.md](docs/RELEASING.md) for the release process.
 
 ## 📱 System Requirements
 
-### Minimum Requirements
-- macOS 15.0 (Sequoia)
-- 4GB RAM
-- 100MB disk space
+### Minimum
+- macOS 26.0 (Tahoe)
+- 4 GB RAM
+- 100 MB disk space
 
 ### Recommended
-- macOS 15.0+ (Sequoia)
-- 8GB+ RAM for large image collections
+- 8 GB+ RAM for large image collections
 - SSD for optimal performance
 
 ### Supported Formats
-| Format | Extension | Notes |
-|--------|-----------|-------|
-| JPEG | .jpg, .jpeg | Full support |
-| HEIC | .heic | Apple's high-efficiency format |
-| GIF | .gif | Including animations |
-| PNG | .png | Coming soon |
+
+| Format | Extension | Status |
+|--------|-----------|--------|
+| JPEG | `.jpg`, `.jpeg` | Supported |
+| HEIC | `.heic` | Supported |
+| GIF | `.gif` | Supported, including animation |
+| PNG | `.png` | Not yet supported |
 | RAW | Various | Planned via plugin system |
 
 ## 🔐 Privacy & Security
 
-- **App Sandbox**: Full sandboxing for system security
-- **File Access**: Read-only access to user-selected folders
-- **No Network**: Completely offline operation
-- **Bookmarks**: Secure persistent access to chosen directories
+- **App Sandbox**: enabled (`com.apple.security.app-sandbox`)
+- **File access**: read-only, and only for folders you explicitly choose (`com.apple.security.files.user-selected.read-only`)
+- **No network access**: SwiftViewer operates entirely offline
+- **No persistent folder access**: security-scoped bookmarks are not used yet, so a folder must be re-selected after relaunch
 
 ## 🐛 Troubleshooting
 
 ### Common Issues
-1. **Images not loading**: Ensure folder has proper read permissions
-2. **Slow performance**: Check available memory and consider reducing cache size
-3. **Slideshow stopping**: Verify repeat mode settings in preferences
+1. **Images not loading** — confirm the folder contains supported formats and is readable
+2. **High memory use** — lower the cache memory limit or preload window in Preferences
+3. **Slideshow stops at the last image** — enable repeat mode (⌘R)
+4. **Controls disappear while browsing** — expected: arrow keys do not wake the control bar. Move the mouse or press any other key to bring it back
 
-### Debug Mode
-Enable debug logging via:
+### Debug Logging
 ```bash
-defaults write com.yourcompany.SwiftViewer debugLoggingEnabled -bool YES
+defaults write oshiire.SwiftViewer debugLoggingEnabled -bool YES
+```
+The logging level (Debug / Info / Warning / Error) can also be set in Preferences.
+
+### Xcode Previews fail with `missing required module 'SwiftShims'`
+A stale explicit-module cache. Quit Xcode and clear it:
+```bash
+rm -rf ~/Library/Developer/Xcode/DerivedData/ModuleCache.noindex
 ```
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary

The README had drifted from the code. Every claim below was checked against the source before editing.

### Factual corrections

| Item | Was | Now | Verified against |
|---|---|---|---|
| Supported macOS | badge `14.0+`, body `15.0` | **26.0 (Tahoe)** | `MACOSX_DEPLOYMENT_TARGET = 26.0` |
| Xcode | `16+` | **26+** | `xcodebuild -version` → 26.6 |
| Fullscreen shortcut | `F` | **⌘F** | `MenuCommands.swift:136` |
| Slideshow intervals | "1–300 seconds" | **13 presets, 1 s – 30 min** | `SlideshowIntervalHelper.intervals` |
| Mouse wheel scrolling | documented | **removed** | no `scrollWheel` / `onScroll` anywhere in `SwiftViewer/` |
| Security-scoped bookmarks | "secure persistent access to chosen directories" | **removed**; states folders must be re-selected after relaunch | entitlements contain only `app-sandbox` + `files.user-selected.read-only`; no `bookmarkData` usage |
| Debug logging bundle id | `com.yourcompany.SwiftViewer` | **`oshiire.SwiftViewer`** | `PRODUCT_BUNDLE_IDENTIFIER` |
| Image loading service | `ImageLoaderService` | **`ImagePipeline`** (actor + `NSCache` + preloader) | `SwiftViewer/Services/ImagePipeline/` |
| PNG | "Coming soon" | **Not yet supported** | `ImageFile.supportedExtensions` = jpg/jpeg/heic/gif |

### Additions
- Complete keyboard shortcut table from `MenuCommands.swift`: ⌘1–⌘3 display modes, ⌥⌘1–3 (+⇧ for descending) sorting, ⌥⌘R random, ⌃⌘T / ⌃⌘B window layering. ↑↓ documented as navigation keys alongside ←→.
- New player behaviour from #51: Liquid Glass controls, drag-to-scrub on the progress bar (navigation commits once on release), and arrow keys not waking the auto-hidden control bar — also listed under Troubleshooting as intended behaviour rather than a bug.
- Configuration ranges: 6 transition types, transition duration 0.1–5.0 s, auto-hide delay 1–60 s (default 3 s), cache memory 1–50 % (default 15 %), count limit 100, preload window 10.
- Development section: test counts (427 unit + 4 UI), `TestCoveragePlan`, SwiftLint, Conventional Commits, the `scripts/verify_prerequisites.sh` pre-commit hook, and a link to `docs/RELEASING.md`.
- Troubleshooting entry for the stale `ModuleCache.noindex` causing `missing required module 'SwiftShims'` in Xcode Previews.

### Deliberately omitted
- **Recent Folders** is not advertised — `MenuCommands.swift:122-126` is a `.disabled(true)` placeholder showing "No Recent Folders".

## Test plan
- [x] Documentation-only change; no source files touched
- [x] Pre-commit hook ran build + full test suite (427 tests, 0 failures)
- [x] Rendered README reads correctly on GitHub (tables, badges, links)
- [x] `docs/RELEASING.md` link resolves
- [x] Spot-check the shortcut table against the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)